### PR TITLE
Implement Agente 3 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # GP_AI_memorist
+
+This repository contains a simple prototype for a multi-agent system. The
+current implementation focuses on **Agente 3** ("Agente del Diseño
+Metodológico y Desarrollo Técnico"), which is responsible for generating a
+methodological design plan for a given project description.
+
+## Usage
+
+```python
+from service.agent3 import DesignMethodologyAgent
+
+agent = DesignMethodologyAgent()
+plan = agent.run("Desarrollo de una plataforma de IA para memoristas")
+print(plan)
+```
+
+The `run` method returns a series of methodological steps to guide the
+technical development of the project.

--- a/service/agent3.py
+++ b/service/agent3.py
@@ -1,0 +1,23 @@
+from service.base import Agent
+
+
+class DesignMethodologyAgent(Agent):
+    """Agent responsible for methodological design and technical development."""
+
+    def __init__(self):
+        super().__init__(
+            name="Agente del Diseño Metodológico y Desarrollo Técnico"
+        )
+
+    def run(self, project_description: str) -> str:
+        """Generate a basic methodological plan given a project description."""
+        steps = [
+            "1. Identificar los requerimientos técnicos y objetivos del proyecto.",
+            "2. Proponer un enfoque metodológico adecuado al alcance.",
+            "3. Definir la arquitectura de desarrollo y herramientas a emplear.",
+            "4. Establecer un plan de pruebas y evaluación técnica.",
+            "5. Documentar el proceso y resultados.",
+        ]
+        if project_description:
+            steps.insert(0, f"Proyecto: {project_description}")
+        return "\n".join(steps)

--- a/service/base.py
+++ b/service/base.py
@@ -1,0 +1,8 @@
+class Agent:
+    """Base class for all agents."""
+    def __init__(self, name: str):
+        self.name = name
+
+    def run(self, input_data: str) -> str:
+        """Process the input data and return a response."""
+        raise NotImplementedError("Agents must implement the run method")


### PR DESCRIPTION
## Summary
- add a basic service package for agents
- implement `DesignMethodologyAgent` (Agente 3)
- document usage in README

## Testing
- `python -m py_compile service/base.py service/agent3.py`
- `python - <<'EOF'
from service.agent3 import DesignMethodologyAgent
agent = DesignMethodologyAgent()
print(agent.run("prueba"))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684c78fd1934832cbdddd5f886578dc5